### PR TITLE
Fix equality after method dispatch changes in Nim

### DIFF
--- a/src/docopt.nim
+++ b/src/docopt.nim
@@ -98,12 +98,12 @@ method `name=`(self: Pattern, name: string) {.base, gcsafe.} =
 
 proc `==`(self, other: Pattern): bool =
     if self.is_nil and other.is_nil:
-      true
+        true
     elif not self.is_nil and not other.is_nil:
-      self.str == other.str
+        self.str == other.str
     else:
-      # Exactly one of the two is nil
-      false
+        # Exactly one of the two is nil
+        false
 
 method flat(self: Pattern,
             types: varargs[string]): seq[Pattern] {.base, gcsafe.} =

--- a/src/docopt.nim
+++ b/src/docopt.nim
@@ -96,8 +96,14 @@ method name(self: Pattern): string {.base, gcsafe.} =
 method `name=`(self: Pattern, name: string) {.base, gcsafe.} =
     self.m_name = name
 
-method `==`(self, other: Pattern): bool {.base, gcsafe, nosideeffect.} =
-    self.str == other.str
+proc `==`(self, other: Pattern): bool =
+    if self.is_nil and other.is_nil:
+      true
+    elif not self.is_nil and not other.is_nil:
+      self.str == other.str
+    else:
+      # Exactly one of the two is nil
+      false
 
 method flat(self: Pattern,
             types: varargs[string]): seq[Pattern] {.base, gcsafe.} =


### PR DESCRIPTION
Replace `==` method on `Pattern` with a simple proc, with explicit nil handling (since no other overloads are present).

Fixes #29 