### PR TITLE
replace unary < with pred and x .. <y with x ..< y for ranges

### DIFF
--- a/examples/odd_even.nim
+++ b/examples/odd_even.nim
@@ -14,5 +14,5 @@ import docopt
 let args = docopt(doc)
 echo args
 
-for i in 0 .. <args["ODD"].len:
+for i in 0 ..< args["ODD"].len:
     echo args["ODD"][i] & " " & args["EVEN"][i]

--- a/src/private/util.nim
+++ b/src/private/util.nim
@@ -38,7 +38,7 @@ proc partition*(s, sep: string): tuple[left, sep, right: string] =
     if pos < 0:
         (s, "", "")
     else:
-        (s.substr(0, <pos), s.substr(pos, <pos+sep.len), s.substr(pos+sep.len))
+        (s.substr(0, pos.pred), s.substr(pos, pos.pred+sep.len), s.substr(pos+sep.len))
 
 
 proc is_upper*(s: string): bool =


### PR DESCRIPTION
unary ``<`` is deprecated now. This PR replaces it.

From the comment in system.nim:
**Deprecated since version 0.18.0**.
For the common excluding range
write ``0 ..< 10`` instead of ``0 .. < 10`` (look at the spacing).
For ``<x`` write ``pred(x)``.