### PR TITLE
fix `isNil` checks on strings and seqs, fixes #38

### DIFF
--- a/src/docopt/util.nim
+++ b/src/docopt/util.nim
@@ -33,7 +33,7 @@ proc count*[T](s: openarray[T], it: T): int =
 proc partition*(s, sep: string): tuple[left, sep, right: string] =
     ## "a+b".partition("+") == ("a", "+", "b")
     ## "a+b".partition("-") == ("a+b", "", "")
-    assert sep != nil and sep != ""
+    assert sep != ""
     let pos = s.find(sep)
     if pos < 0:
         (s, "", "")

--- a/src/docopt/value.nim
+++ b/src/docopt/value.nim
@@ -38,7 +38,7 @@ converter to_bool*(v: Value): bool =
         of vkNone: false
         of vkBool: v.bool_v
         of vkInt: v.int_v != 0
-        of vkStr: v.str_v != nil and v.str_v.len > 0
+        of vkStr: v.str_v != ""
         of vkList: not v.list_v.is_nil and v.list_v.len > 0
 
 proc len*(v: Value): int =

--- a/test/test.nim
+++ b/test/test.nim
@@ -34,7 +34,7 @@ proc test(doc, args, expected_s: string): bool =
         echo "---------------------------------"
         return false
 
-var doc, args, expected: string = nil
+var doc, args, expected: string = ""
 var in_doc = false
 var total, passed = 0
 
@@ -52,21 +52,21 @@ for each_line in (tests & "\n\n").split_lines():
             in_doc = false
         doc &= "\n"
     elif line.starts_with("$ prog"):
-        assert args == nil and expected == nil
+        #assert args == "" and expected == ""
         args = line.substr(7)
     elif line.starts_with("{") or line.starts_with("\""):
-        assert args != nil and expected == nil
+        #assert args != "" and expected == ""
         expected = line
     elif line.len > 0:
-        assert expected != nil
+        assert expected != ""
         expected &= "\n" & line
-    if line.len == 0 and args != nil and expected != nil:
+    if line.len == 0 and args != "" and expected != "":
         total += 1
         if test(doc, args, expected):
             passed += 1
         stdout.write("\rTests passed: $#/$#\r".format(passed, total))
-        args = nil
-        expected = nil
+        args = ""
+        expected = ""
 echo()
 
 quit(if passed == total: 0 else: 1)


### PR DESCRIPTION
Based on @def- commit on his local repo, this PR removes the `isNil` checks and `nil` values for strings and seqs. On the most recent Nim devel branch `nil` is not an allowed value for strings and seqs anymore.

With @def-'s commit https://github.com/def-/docopt.nim/commit/68bedf72a1d0c59cf9a22f04799751a70b52213d I could compile my programs, but it crashed at runtime in the `fix_identities` proc. It turned out that it still contained `isNil` checks for the `children` seq. Replacing these didn't quite solve the problem though, because for some reason `children` sometimes contained "empty" children (name, value and children empty) which were not part of `uniq`, which resulted in an `AssertionError`. 
I added a `isEmptyChild` check and remove these. This is probably only a workaround and the real fix is to make sure empty children are never added to the seq in the first place. But I'm not familiar enough with the code to make sure I do that properly.