### PR TITLE
Remove pcre dependency by using regex instead of nre

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,23 +18,22 @@ install:
       rm -rf csources
       bin/nim c koch
       ./koch boot -d:release
+      ./koch nimble
     else
       cd nim-$nim_branch
       git fetch origin
       if ! git merge FETCH_HEAD | grep "Already up-to-date"; then
         bin/nim c koch
         ./koch boot -d:release
+        ./koch nimble
       fi
     fi
     cd ..
 before_script:
   - export PATH="nim-$nim_branch/bin${PATH:+:$PATH}"
+  - export NIM_LIB_PREFIX="$(pwd)/nim-$nim_branch"
 script:
-  - nim compile --verbosity:0 --run test/test
-  - |
-    for f in examples/*.nim; do
-      nim compile --verbosity:0 --hints:off "$f" || exit
-    done
+  - nimble test
 cache:
   directories:
     - nim-master

--- a/docopt.nimble
+++ b/docopt.nimble
@@ -8,6 +8,6 @@ requires "nim >= 0.15.0"
 requires "regex >= 0.7.4"
 
 task test, "Test":
-  exec "nim compile --verbosity:0 --run test/test"
+  exec "nimble c --verbosity:0 -r -y test/test"
   for f in listFiles("examples"):
     if f[^4..^1] == ".nim": exec "nim compile --verbosity:0 --hints:off " & f

--- a/docopt.nimble
+++ b/docopt.nimble
@@ -5,6 +5,7 @@ license = "MIT"
 srcDir = "src"
 
 requires "nim >= 0.15.0"
+requires "regex >= 0.7.4"
 
 task test, "Test":
   exec "nim compile --verbosity:0 --run test/test"

--- a/src/docopt.nim
+++ b/src/docopt.nim
@@ -3,7 +3,7 @@
 # Licensed under terms of MIT license (see LICENSE)
 
 
-import nre, options, os, tables
+import regex, options, os, tables
 from sequtils import deduplicate, delete, filter_it
 import docopt/util
 
@@ -266,7 +266,8 @@ proc option_parse[T](
     if argcount > 0:
         var m = description.find(re"(?i)\[default:\ (.*)\]")
         if m.is_some:
-            value = val(m.get.captures[0])
+            let bounds = m.get.group(0)[0]
+            value = val(description.substr(bounds.a, bounds.b))
         else:
             value = val()
     constructor(short, long, argcount, value)
@@ -532,7 +533,7 @@ proc parse_argv(tokens: TokenStream, options: var seq[Option],
 
 
 proc parse_defaults(doc: string): seq[Option] =
-    var split = doc.split(re"\n\ *(<\S+?>|-\S+?)")
+    var split = doc.splitIncl(re"\n\ *(<\S+?>|-\S+?)")
     result = @[]
     for i in 1 .. split.len div 2:
         var s = split[i*2-1] & split[i*2]
@@ -541,7 +542,7 @@ proc parse_defaults(doc: string): seq[Option] =
 
 
 proc printable_usage(doc: string): string =
-    var usage_split = doc.split(re"(?i)(Usage:)")
+    var usage_split = doc.splitIncl(re"(?i)(Usage:)")
     if usage_split.len < 3:
         raise new_exception(DocoptLanguageError,
             """"usage:" (case-insensitive) not found.""")
@@ -549,7 +550,7 @@ proc printable_usage(doc: string): string =
         raise new_exception(DocoptLanguageError,
             """More than one "usage:" (case-insensitive).""")
     usage_split.delete(0)
-    usage_split.join().split(re"\n\s*\n")[0].strip()
+    usage_split.join().splitIncl(re"\n\s*\n")[0].strip()
 
 
 proc formal_usage(printable_usage: string): string =


### PR DESCRIPTION
Addresses issue https://github.com/docopt/docopt.nim/issues/33.

This replaces the [nre](https://nim-lang.org/docs/nre.html) module with [regex](https://github.com/nitely/nim-regex). nitely recently added [support for split with captures](https://github.com/nitely/nim-regex/issues/8) with the `splitIncl` proc.

It looks like thanks to nitelys work only these small changes are needed now to replace nre, the tests all passed.