### PR TITLE
Updating compatibility with the new nim version..

### DIFF
--- a/src/docopt.nim
+++ b/src/docopt.nim
@@ -2,15 +2,13 @@
 # Copyright (C) 2015 Oleh Prypin <blaxpirit@gmail.com>
 # Licensed under terms of MIT license (see LICENSE)
 
-
-import regex, options, os, tables
-from sequtils import deduplicate, delete, filter_it
-import docopt/util
+from sequtils import allIt, deduplicate, delete, filter_it
+import std/[options, os, tables]
+import regex
 
 export tables
 
 include docopt/value
-
 
 type
   DocoptLanguageError* = object of Exception
@@ -142,7 +140,7 @@ method either(self: Pattern): Either {.base, gcsafe.} =
       for i, c in children:
         if c.class in parents:
           child = c
-          children.delete(i, i)
+          children.delete(i..i)
           break
       assert child != nil
       if child.class == "Either":

--- a/src/docopt/dispatch.nim
+++ b/src/docopt/dispatch.nim
@@ -1,4 +1,9 @@
-import docopt, macros, strutils, sequtils, typetraits
+# Copyright (C) 2015 Oleh Prypin <blaxpirit@gmail.com>
+# Licensed under terms of MIT license (see LICENSE)
+
+from sequtils import allIt
+import std/[strbasics, strutils, macros, typetraits]
+import docopt
 
 macro runUserImplemented(x: typed, fallback: untyped): untyped =
   ## This macro takes a type from a generic and checks if there exists a

--- a/src/docopt/util.nim
+++ b/src/docopt/util.nim
@@ -1,9 +1,7 @@
 # Copyright (C) 2015 Oleh Prypin <blaxpirit@gmail.com>
 # Licensed under terms of MIT license (see LICENSE)
 
-
-import strutils, unicode, macros
-
+import std/[strutils, unicode, macros]
 
 template any_it*(lst: typed, pred: untyped): bool =
   ## Does `pred` return true for any of the `it`s of `lst`?

--- a/src/docopt/value.nim
+++ b/src/docopt/value.nim
@@ -1,10 +1,8 @@
 # Copyright (C) 2015 Oleh Prypin <blaxpirit@gmail.com>
 # Licensed under terms of MIT license (see LICENSE)
 
-
-import strutils
+import std/[strutils]
 import util
-
 
 type
   ValueKind* = enum


### PR DESCRIPTION
This partially fixed compatibility with the latest nim version. What remains is the following:

1. For some reason in the `dispatch.nim` file it doesn't recognize the `allIt` routine even though I called it at the beginning. However, if you call it again in the file you are working in, then it will work.

2. If you use `seq[string]` in the function you will call from `dispatchProc`, you will get the following `Error: unhandled exception: field 'list_v' is not accessible for type 'Value' using 'kind = vkStr' [FieldDefect]` on runtime. Any other type will work except sequence..