### PR TITLE
make docopt compile with stricteffects

### DIFF
--- a/src/docopt.nim
+++ b/src/docopt.nim
@@ -248,7 +248,8 @@ method single_match(self: Command, left: seq[Pattern]): SingleMatchResult =
 
 
 proc option_parse[T](
-  constructor: proc(short, long: string; argcount: int; value: Value): T {.gcsafe.},
+  constructor: proc(short, long: string; argcount: int;
+      value: Value): T {.gcsafe.},
   option_description: string): T =
   var short, long: string = ""
   var argcount = 0

--- a/src/docopt.nim
+++ b/src/docopt.nim
@@ -248,7 +248,7 @@ method single_match(self: Command, left: seq[Pattern]): SingleMatchResult =
 
 
 proc option_parse[T](
-  constructor: proc(short, long: string; argcount: int; value: Value): T,
+  constructor: proc(short, long: string; argcount: int; value: Value): T {.gcsafe.},
   option_description: string): T =
   var short, long: string = ""
   var argcount = 0


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/19380

Otherwise it complains with "Error: 'option_parse' is not GC-safe as it performs an indirect call via 'constructor'"